### PR TITLE
[UI] 버튼 width와 margin 수정

### DIFF
--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -47,10 +47,8 @@ CircleButton.propTypes = {
 export { MainPrimaryButton, SubPrimaryButton, SecondaryButton, CircleButton };
 
 const MainPrimaryButtonLayout = styled.button`
-  max-width: 720px;
-  width: 90%;
+  width: 100%;
   padding: 14px 24px;
-  margin: 24px;
   border-radius: 12px;
   font-size: 18px;
   font-weight: 800;
@@ -92,7 +90,6 @@ const SubPrimaryButtonLayout = styled(MainPrimaryButtonLayout)`
 const SecondaryButtonLayout = styled.button`
   width: 122px;
   padding: 7px 16px;
-  margin: 24px;
   border-radius: 6px;
   font-size: 16px;
   font-weight: 400;


### PR DESCRIPTION
### 📝 Description
- MainPrimary 버튼의 width를 100%로 수정
- 모든 버튼의 margin 속성 삭제

--- 
### 📷 ScreenShot


---

### ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-%EC%BB%A4%EB%B0%8B-%EB%A9%94%EC%8B%9C%EC%A7%80-%EC%BB%A8%EB%B2%A4%EC%85%98>커밋 컨벤션 참고</a>
