### PR TITLE
[feat] post/{id} 페이지 레이아웃

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -94,7 +94,7 @@ const CardContent = styled.p`
   line-height: 26px;
   letter-spacing: -0.18px;
   max-width: 336px;
-  max-height: 106px;
+  height: 106px;
   display: -webkit-box;
   -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -29,12 +29,21 @@ const CardWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 16px;
-  max-width: 384px;
-  max-height: 280px;
+  width: 384px;
+  height: 280px;
   padding: 28px 24px;
   border-radius: 16px;
   background: ${({ theme }) => theme.white};
   box-shadow: 0px 2px 12px 0px rgba(0, 0, 0, 0.08);
+  ${({ theme }) => theme.tablet`
+    width: 352px;
+    height: 284px;
+  `}
+
+  ${({ theme }) => theme.mobile`
+    width: 320px;
+    height: 230px;
+  `}
 `;
 
 const ProfileWrapper = styled.div`
@@ -70,6 +79,9 @@ const ProfileContentText = styled.span`
   font-style: normal;
   font-weight: ${(props) => props.weight || 400};
   line-height: 24px;
+  ${({ theme }) => theme.mobile`
+    font-size: 18px;
+  `}
 `;
 
 const CardContent = styled.p`
@@ -81,11 +93,21 @@ const CardContent = styled.p`
   font-weight: 400;
   line-height: 26px;
   letter-spacing: -0.18px;
-  width: 336px;
-  height: 106px;
+  max-width: 336px;
+  max-height: 106px;
   display: -webkit-box;
   -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;
+  ${({ theme }) => theme.tablet`
+    width: 304px;
+    height: 110px;
+  `}
+  ${({ theme }) => theme.mobile`
+    width: 272px;
+    height: 56px;
+    font-size: 15px;
+    line-height: 22px;
+  `}
 `;
 
 const CardTimeStamp = styled.span`

--- a/src/pages/PostPage.js
+++ b/src/pages/PostPage.js
@@ -60,15 +60,31 @@ const PostPageWrapper = styled.div`
   align-items: center;
   justify-content: center;
   background-color: ${({ theme }) => theme['--orange-200']};
+  @media (max-width: 1248px) {
+    padding: 0px 24px;
+  }
 `;
 
 const CardListWrapper = styled.div`
   width: 1200px;
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: auto;
   column-gap: 24px;
   row-gap: 28px;
+  margin-top: 113px;
+  ${({ theme }) => theme.tablet`
+    row-gap: 16px;
+    column-gap: 16px;
+    grid-template-columns: repeat(2, 1fr);
+    place-items: center;
+  `}
+  ${({ theme }) => theme.mobile`
+    row-gap: 16px;
+    column-gap: 16px;
+    grid-template-columns: 1fr;
+    place-items: center;
+  `}
 `;
 
 const Target = styled.div`


### PR DESCRIPTION
### 📝 Description
- post 페이지 모바일 태블릿 반응형 레이아웃 구현.
- flex wrap -> grid 로 변경.
### 📷 ScreenShot
![post-page-pc](https://github.com/codeit-1st-team5/rolling/assets/90304025/ee1ebb16-28be-4428-8d63-164a1e72b1a2)
![post-page-tablet](https://github.com/codeit-1st-team5/rolling/assets/90304025/ab046968-7327-426f-8182-9384803e524b)
![post-page-mobile](https://github.com/codeit-1st-team5/rolling/assets/90304025/2790eade-a118-41d8-94f2-06e9fb651ed7)

---

### ✅ PR CheckList

- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-%EC%BB%A4%EB%B0%8B-%EB%A9%94%EC%8B%9C%EC%A7%80-%EC%BB%A8%EB%B2%A4%EC%85%98>커밋 컨벤션 참고</a>
