### PR TITLE
[feat] 인기 롤링 페이퍼 리액션 수대로 정렬, 페이징 구현

### DIFF
--- a/src/components/CardList/RecentCardList.js
+++ b/src/components/CardList/RecentCardList.js
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { ReactComponent as NextIcon } from 'assets/icons/arrow_right.svg';
+import styled from 'styled-components';
+import Card from 'components/CardList/Card';
+import useRequest from 'hooks/useRequest';
+
+function RecentCardList({ title }) {
+  const [offset, setOffset] = useState(0);
+
+  const { data, isLoading, error } = useRequest({
+    url: `1-5/recipients/`,
+    method: 'get',
+    params: { limit: 4, offset },
+    deps: offset,
+  });
+
+  function handleNextClick() {
+    setOffset((prevOffset) => prevOffset + 4);
+  }
+
+  function handlePreviousClick() {
+    setOffset((prevOffset) => prevOffset - 4);
+  }
+
+  const results = data.results || [];
+  if (isLoading) return <p>로딩 중...</p>;
+  if (error) return <p>데이터 로딩 에러: {error.message}</p>;
+
+  return (
+    <ListPageContainer>
+      <Title>{title}</Title>
+      <CardListContainer>
+        {data.previous && (
+          <NavigationButton
+            onClick={handlePreviousClick}
+            position="left"
+            isVisible={!!data.previous}
+          >
+            <PreviousIcon />
+          </NavigationButton>
+        )}
+        {results.map((card) => (
+          <Card key={card.id} card={card} />
+        ))}
+        {data.next && (
+          <NavigationButton
+            onClick={handleNextClick}
+            position="right"
+            isVisible={!!data.next}
+          >
+            <NextIcon />
+          </NavigationButton>
+        )}
+      </CardListContainer>
+    </ListPageContainer>
+  );
+}
+
+export default RecentCardList;
+
+const ListPageContainer = styled.div`
+  width: 1160px;
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+`;
+
+const Title = styled.h2`
+  color: #000;
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 36px;
+  letter-spacing: -0.24px;
+  margin-bottom: 16px;
+`;
+
+const CardListContainer = styled.div`
+  display: flex;
+  gap: 20px;
+  margin-bottom: 50px;
+  position: relative;
+`;
+
+const NavigationButton = styled.button`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid #dadcdf;
+  position: absolute;
+  z-index: 2;
+  background: #fff;
+  top: 110px;
+  visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
+  ${({ position }) => (position === 'left' ? 'left: -20px;' : 'right: -20px;')}
+`;
+
+const PreviousIcon = styled(NextIcon)`
+  transform: scaleX(-1);
+`;

--- a/src/components/CardList/index.js
+++ b/src/components/CardList/index.js
@@ -1,1 +1,0 @@
-export { default } from './CardList';

--- a/src/pages/ListPage.js
+++ b/src/pages/ListPage.js
@@ -1,12 +1,13 @@
-import CardList from 'components/CardList';
+import RecentCardList from 'components/CardList/RecentCardList';
+import ReactionCardList from 'components/CardList/ReactionCardList';
 import styled from 'styled-components';
 import { MainPrimaryButton } from 'components/button/Button';
 
 function ListPage() {
   return (
     <ListPageContainer>
-      <CardList title="인기 롤링 페이퍼 🔥" />
-      <CardList title="최근에 만든 롤링 페이퍼 ⭐️️" />
+      <ReactionCardList title="인기 롤링 페이퍼 🔥" />
+      <RecentCardList title="최근에 만든 롤링 페이퍼 ⭐️️" />
       <MainPrimaryButton title="나도 만들어보기" className="list-page-button" />
     </ListPageContainer>
   );

--- a/src/pages/ListPage.js
+++ b/src/pages/ListPage.js
@@ -18,5 +18,5 @@ const ListPageContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 144px auto 218px;
+  margin: 50px auto 218px;
 `;


### PR DESCRIPTION
### 📝 Description

- 인기 롤링 페이퍼 리액션 수대로 정렬, 페이징 구현
- 리액션 수대로 정렬하기 위해서 전체 데이터를 조회해야하므로 기존 CardList 컴포넌트를 리액션카드리스트, 최신순카드리스트로 분리
- 리액션 카드리스트는 전체 데이터를 조회하므로 따로 페이징 구현
- #67 

### 📷 ScreenShot

<img width="1435" alt="스크린샷 2023-11-12 오후 10 55 47" src="https://github.com/codeit-1st-team5/rolling/assets/72639353/b840103f-4410-4653-9950-3d20c48efa6a">


### ✅ PR CheckList

- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-%EC%BB%A4%EB%B0%8B-%EB%A9%94%EC%8B%9C%EC%A7%80-%EC%BB%A8%EB%B2%A4%EC%85%98>커밋 컨벤션 참고</a>
