### PR TITLE
[refactor] 토스트메세지 css 코드 위치 수정

### DIFF
--- a/src/components/ShareTab/LinkShareButton.js
+++ b/src/components/ShareTab/LinkShareButton.js
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import 'react-toastify/dist/ReactToastify.css';
 import openToast from 'utils/openToast';
 
 function LinkShareButton({ resultUrl }) {

--- a/src/utils/openToast.js
+++ b/src/utils/openToast.js
@@ -2,6 +2,7 @@
 // 토스트에 넣을 메세지는 txt 안에 적어주세요.
 //
 import { toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 function openToast({ type = 'success', txt = 'notification!' }) {
   if (type !== ('success' || 'error' || 'warning')) return;


### PR DESCRIPTION
### 📝 Description
- utils 폴더의 openToast 메소드에 css 파일 추가했습니다. 
- ***

### 📷 ScreenShot

---

### ✅ PR CheckList

- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-%EC%BB%A4%EB%B0%8B-%EB%A9%94%EC%8B%9C%EC%A7%80-%EC%BB%A8%EB%B2%A4%EC%85%98>커밋 컨벤션 참고</a>
