### PR TITLE
[feat] headerService에 ProfileAndMessage 컴포넌트 추가

### DIFF
--- a/src/components/HeaderService/HeaderService.js
+++ b/src/components/HeaderService/HeaderService.js
@@ -2,19 +2,21 @@
 import styled from 'styled-components';
 import Emoji from 'components/Emoji/Emoji';
 import ShareTab from 'components/ShareTab/ShareTab';
+import ProfileAndMessage from './ProfileAndMessage';
 
 function HeaderService({ card }) {
   //const location = useLocation();
   // /post/{id}
   //const getNav = location.pathname.startsWith('/post/');
-
   return (
     <HeaderServiceLayout>
       <div className="header-service-container">
         {
           <>
             <div className="to">To. {card.name} </div>
+
             <div className="header-service-contents">
+              <ProfileAndMessage card={card} />
               <Emoji />
               <ShareTab />
             </div>
@@ -29,7 +31,7 @@ export default HeaderService;
 
 const HeaderServiceLayout = styled.nav`
   position: fixed;
-  top: 62;
+  top: 62px;
   width: 100%;
   background-color: ${({ theme }) => theme[`white`]};
   border-bottom: 1px solid ${({ theme }) => theme[`--gray-300`]};

--- a/src/components/HeaderService/ProfileAndMessage.js
+++ b/src/components/HeaderService/ProfileAndMessage.js
@@ -1,0 +1,101 @@
+import styled, { css } from 'styled-components';
+import theme from 'styles/theme';
+
+function ProfileAndMessage({ card }) {
+  return card.messageCount > 0 ? (
+    <Wrapper>
+      <Profile>
+        {card.recentMessages.map((message) => (
+          <ProfileImg
+            key={message.id}
+            src={message.profileImageURL}
+            alt={`${message.sender}'s profile`}
+          />
+        ))}
+        <ProfileCount>
+          +{card.messageCount - card.recentMessages.length}
+        </ProfileCount>
+      </Profile>
+      <MessageCount>
+        <StyledSpan>{card.messageCount}</StyledSpan>
+        명이 작성했어요!
+      </MessageCount>
+      <VerticalLine />
+    </Wrapper>
+  ) : (
+    <></>
+  );
+}
+
+export default ProfileAndMessage;
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 11px;
+
+  ${({ theme }) => theme.tablet`
+    display: none;
+  `};
+`;
+const VerticalLine = styled.div`
+  width: 1px;
+  height: 28px;
+  border-right: 1px solid ${theme['--gray-200']};
+  margin: 0 2px 0 28px;
+`;
+
+const imgStyles = css`
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1.5px solid ${({ theme }) => theme['white']};
+  background: ${({ theme }) => theme['white']};
+`;
+
+const Profile = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  margin: 12px 0;
+`;
+
+const ProfileImg = styled.img`
+  ${imgStyles}
+  &:not(:first-child) {
+    margin-left: -12px;
+  }
+`;
+
+const ProfileCount = styled.div`
+  ${imgStyles};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: -12px;
+  border-color: #e3e3e3;
+
+  text-align: center;
+  font-size: 12px;
+  font-weight: 500;
+  color: #484848;
+  line-height: 28px;
+`;
+
+const MessageCount = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  line-height: 27px;
+  font-size: 18px;
+  font-weight: 400;
+  color: ${theme['--gray-900']};
+`;
+
+const StyledSpan = styled.span`
+  line-height: 27px;
+  font-size: 18px;
+  font-weight: 700;
+  color: ${theme['--gray-900']};
+`;


### PR DESCRIPTION
### 📝 Description

- headerService에 ProfileAndMessage 컴포넌트 추가
- tablet, mobile에서는 보이지 않도록 설정했습니다.
- Close #84 

### 📷 ScreenShot
![image](https://github.com/codeit-1st-team5/rolling/assets/96380950/7102f4b2-bc2d-426c-a36e-e081c1dc8695)
![image](https://github.com/codeit-1st-team5/rolling/assets/96380950/0513ef2d-eb2e-438d-a991-09a6681311ed)

---

### ✅ PR CheckList

- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-%EC%BB%A4%EB%B0%8B-%EB%A9%94%EC%8B%9C%EC%A7%80-%EC%BB%A8%EB%B2%A4%EC%85%98>커밋 컨벤션 참고</a>
