### PR TITLE
[refactor] Card컴포넌트에서 ProfileAndMessage컴포넌트를 사용할 수 있도록 수정

### DIFF
--- a/src/components/CardList/Card.js
+++ b/src/components/CardList/Card.js
@@ -1,6 +1,7 @@
 import { ReactComponent as Pattern } from 'assets/icons/card-list-pattern-icon.svg';
 import styled, { css } from 'styled-components';
 import { Link } from 'react-router-dom';
+import ProfileAndMessage from '../HeaderService/ProfileAndMessage';
 
 const Card = ({ card }) => {
   const textColor = !card.backgroundImageURL
@@ -16,22 +17,7 @@ const Card = ({ card }) => {
         >
           {!card.backgroundImageURL && <PatternSVG />}
           <Name textColor={textColor}>To. {card.name}</Name>
-          <Profile>
-            {card.recentMessages.map((message) => (
-              <ProfileImg
-                key={message.id}
-                src={message.profileImageURL}
-                alt={`${message.sender}'s profile`}
-              />
-            ))}
-            <ProfileCount>
-              +{card.messageCount - card.recentMessages.length}
-            </ProfileCount>
-          </Profile>
-          <MessageCount textColor={textColor}>
-            <StyledSpan textColor={textColor}>{card.messageCount}</StyledSpan>
-            명이 작성했어요!
-          </MessageCount>
+          <ProfileAndMessage card={card} type="card" />
           <CardFooter>
             {card.topReactions.map((reaction) => (
               <TopReactions key={reaction.id}>
@@ -47,19 +33,19 @@ const Card = ({ card }) => {
 
 export default Card;
 
-const fontStyles = css`
-  line-height: 150%;
-  letter-spacing: -0.16px;
-  color: ${({ theme }) => theme['--gray-700']};
-`;
-
-const imgStyles = css`
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  border: 1.5px solid ${({ theme }) => theme['white']};
-  background: ${({ theme }) => theme['white']};
-`;
+// const fontStyles = css`
+//   line-height: 150%;
+//   letter-spacing: -0.16px;
+//   color: ${({ theme }) => theme['--gray-700']};
+// `;
+//
+// const imgStyles = css`
+//   width: 28px;
+//   height: 28px;
+//   border-radius: 50%;
+//   border: 1.5px solid ${({ theme }) => theme['white']};
+//   background: ${({ theme }) => theme['white']};
+// `;
 
 const CardContainer = styled.div`
   ${({ theme, backgroundColor, backgroundImage }) => css`
@@ -100,50 +86,50 @@ const Name = styled.div`
   color: ${({ textColor }) => textColor};
 `;
 
-const Profile = styled.div`
-  display: flex;
-  align-items: center;
-  position: relative;
-  margin: 12px 0;
-`;
-
-const ProfileImg = styled.img`
-  ${imgStyles}
-  &:not(:first-child) {
-    margin-left: -12px;
-  }
-`;
-
-const ProfileCount = styled.div`
-  ${fontStyles}
-  ${imgStyles}
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 33px;
-  padding: 5px 6px;
-  border-radius: 30px;
-  margin-left: -12px;
-  font-size: 12px;
-  font-weight: 400;
-  color: ${({ theme }) => theme['--gray-500']};
-`;
-
-const MessageCount = styled.div`
-  line-height: 150%;
-  letter-spacing: -0.16px;
-  font-size: 16px;
-  font-weight: 400;
-  color: ${({ textColor }) => textColor};
-`;
-
-const StyledSpan = styled.span`
-  line-height: 150%;
-  letter-spacing: -0.16px;
-  font-size: 16px;
-  font-weight: 700;
-  color: ${({ textColor }) => textColor};
-`;
+// const Profile = styled.div`
+//   display: flex;
+//   align-items: center;
+//   position: relative;
+//   margin: 12px 0;
+// `;
+//
+// const ProfileImg = styled.img`
+//   ${imgStyles}
+//   &:not(:first-child) {
+//     margin-left: -12px;
+//   }
+// `;
+//
+// const ProfileCount = styled.div`
+//   ${fontStyles}
+//   ${imgStyles}
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
+//   width: 33px;
+//   padding: 5px 6px;
+//   border-radius: 30px;
+//   margin-left: -12px;
+//   font-size: 12px;
+//   font-weight: 400;
+//   color: ${({ theme }) => theme['--gray-500']};
+// `;
+//
+// const MessageCount = styled.div`
+//   line-height: 150%;
+//   letter-spacing: -0.16px;
+//   font-size: 16px;
+//   font-weight: 400;
+//   color: ${({ textColor }) => textColor};
+// `;
+//
+// const StyledSpan = styled.span`
+//   line-height: 150%;
+//   letter-spacing: -0.16px;
+//   font-size: 16px;
+//   font-weight: 700;
+//   color: ${({ textColor }) => textColor};
+// `;
 
 const CardFooter = styled.div`
   display: flex;

--- a/src/components/HeaderService/HeaderService.js
+++ b/src/components/HeaderService/HeaderService.js
@@ -16,7 +16,7 @@ function HeaderService({ card }) {
             <div className="to">To. {card.name} </div>
 
             <div className="header-service-contents">
-              <ProfileAndMessage card={card} />
+              <ProfileAndMessage card={card} type="headerService" />
               <Emoji />
               <ShareTab />
             </div>

--- a/src/components/HeaderService/ProfileAndMessage.js
+++ b/src/components/HeaderService/ProfileAndMessage.js
@@ -1,29 +1,50 @@
 import styled, { css } from 'styled-components';
 import theme from 'styles/theme';
 
-function ProfileAndMessage({ card }) {
-  return card.messageCount > 0 ? (
-    <Wrapper>
-      <Profile>
-        {card.recentMessages.map((message) => (
-          <ProfileImg
-            key={message.id}
-            src={message.profileImageURL}
-            alt={`${message.sender}'s profile`}
-          />
-        ))}
-        <ProfileCount>
-          +{card.messageCount - card.recentMessages.length}
-        </ProfileCount>
-      </Profile>
-      <MessageCount>
-        <StyledSpan>{card.messageCount}</StyledSpan>
+function ProfileAndMessage({ card, type }) {
+  const styleObj = {
+    headerService: {
+      textColor: theme['--gray-900'],
+      fontSize: '18px',
+      fontWeight: 500,
+      border: 'none',
+      borderColor: '#E3E3E3',
+    },
+    card: {
+      textColor: !card.backgroundImageURL
+        ? theme['--gray-700']
+        : theme['white'],
+      fontSize: '16px',
+      fontWeight: 400,
+      borderColor: theme['white'],
+    },
+  };
+  return (
+    <Wrapper type={type}>
+      {card.messageCount > 0 && (
+        <Profile>
+          {card.recentMessages.map((message) => (
+            <ProfileImg
+              key={message.id}
+              src={message.profileImageURL}
+              alt={`${message.sender}'s profile`}
+            />
+          ))}
+          {card.messageCount > 3 && (
+            <ProfileCount styleObj={styleObj[type]}>
+              +{card.messageCount - card.recentMessages.length}
+            </ProfileCount>
+          )}
+        </Profile>
+      )}
+      <MessageCount styleObj={styleObj[type]}>
+        <StyledSpan styleObj={styleObj[type]}>
+          {card.messageCount || 0}
+        </StyledSpan>
         명이 작성했어요!
       </MessageCount>
-      <VerticalLine />
+      {type === 'headerService' && <VerticalLine />}
     </Wrapper>
-  ) : (
-    <></>
   );
 }
 
@@ -35,7 +56,7 @@ const Wrapper = styled.div`
   gap: 11px;
 
   ${({ theme }) => theme.tablet`
-    display: none;
+    display: ${({ type }) => (type === 'headerService' ? 'none' : 'auto')};
   `};
 `;
 const VerticalLine = styled.div`
@@ -73,7 +94,7 @@ const ProfileCount = styled.div`
   justify-content: center;
   align-items: center;
   margin-left: -12px;
-  border-color: #e3e3e3;
+  border-color: ${({ styleObj }) => styleObj.borderColor};
 
   text-align: center;
   font-size: 12px;
@@ -86,16 +107,17 @@ const MessageCount = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  margin: 12px 0;
 
   line-height: 27px;
-  font-size: 18px;
+  font-size: ${({ styleObj }) => styleObj.fontSize};
   font-weight: 400;
-  color: ${theme['--gray-900']};
+  color: ${({ styleObj }) => styleObj.textColor};
 `;
 
 const StyledSpan = styled.span`
   line-height: 27px;
-  font-size: 18px;
+  font-size: ${({ styleObj }) => styleObj.fontSize};
   font-weight: 700;
-  color: ${theme['--gray-900']};
+  color: ${({ styleObj }) => styleObj.textColor};
 `;


### PR DESCRIPTION
### 📝 Description

- Card컴포넌트에서 ProfileAndMessage컴포넌트를 사용할 수 있도록 수정했습니다.
- Card에서 부를 때와 HeaderService에서 부를 때에 스타일 변화가 많지 않을것이라고 생각해서 
![image](https://github.com/codeit-1st-team5/rolling/assets/96380950/a8fc2837-ae58-4dfe-9664-ffea43f46099)
위와같이 각 타입의 스타일을 저장해놓고, 아래와 같이 분기할 계획이었지만
![image](https://github.com/codeit-1st-team5/rolling/assets/96380950/f55406d2-3042-413e-ae77-55525a232b58)

생각보다 가독성이 안좋아져서 다시 수정해보겠습니다 👍 
- 테스트를 해보려면 Card컴포넌트쪽의 소스를 수정해봐야했어서 제가 커밋했습니다..! 이슬님이 작성해주신 코드는 주석만 했으니 잘못된 부분이 있는지 확인부탁드립니다!!
- Close #122 


### 📷 ScreenShot
![image](https://github.com/codeit-1st-team5/rolling/assets/96380950/e30e0f20-0d96-4d46-8c24-7dc2e30aebab)
![image](https://github.com/codeit-1st-team5/rolling/assets/96380950/80ac9fb2-ce15-4782-a1bc-436a3513aad4)


---

### ✅ PR CheckList

- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-%EC%BB%A4%EB%B0%8B-%EB%A9%94%EC%8B%9C%EC%A7%80-%EC%BB%A8%EB%B2%A4%EC%85%98>커밋 컨벤션 참고</a>
